### PR TITLE
Fix reference error to non-existent this.connection

### DIFF
--- a/src/tedious.coffee
+++ b/src/tedious.coffee
@@ -628,7 +628,7 @@ module.exports = (Connection, Transaction, Request, ConnectionError, Transaction
 							return
 						
 						if isChunkedRecordset
-							if columns[JSON_COLUMN_ID] and @connection.config.parseJSON is true
+							if columns[JSON_COLUMN_ID] and connection.config.parseJSON is true
 								try
 									row = JSON.parse chunksBuffer.join ''
 								catch ex


### PR DESCRIPTION
When checking for the connection.config.parseJSON flag the coffeescript incorrectly adds "this." to the front even though the connection is the ambient scope variable "connection" -- should also be corrected in tedious.coffee to remove the '@'

This pull request echos the one on /v4 branch

Found this when returning JSON column